### PR TITLE
Add GRO conceptual model and docs

### DIFF
--- a/docs/GRO.md
+++ b/docs/GRO.md
@@ -1,0 +1,24 @@
+# Gravedad Relativista Oscura (GRO)
+
+Este documento explora una alternativa conceptual para explicar los efectos atribuidos a la materia oscura partiendo de la relatividad general de Einstein.
+
+## 1. Ideas de Einstein sobre la gravedad
+- La gravedad surge de la curvatura del espacio-tiempo.
+- Introdujo la constante cosmológica \(\Lambda\) para permitir soluciones estáticas, aunque más tarde la calificó como un "error".
+
+## 2. Contraste con la materia oscura
+- Observaciones de rotación galáctica y lentes gravitacionales muestran más atracción de la que predicen las estrellas visibles.
+- Normalmente se propone materia oscura como partículas invisibles para explicar estos fenómenos.
+
+## 3. Hipótesis
+- Una lectura moderna de \(\Lambda\) podría interpretarse como un residuo geométrico que produce efectos oscuros.
+- La geometría del espacio-tiempo podría modificarse ligeramente a escalas galácticas sin requerir nueva materia.
+
+## 4. Modelo "Gravedad Relativista Oscura"
+- Propone un potencial gravitacional modificado:
+  \[\Phi(r) = -\frac{GM}{r} \bigl(1 + \alpha e^{-r/r_0}\bigr)\]
+- El término exponencial introduce una atracción adicional que decae con la distancia.
+- Ajustando los parámetros \(\alpha\) y \(r_0\) se puede emular la rotación plana de las galaxias.
+
+## 5. Ejemplo de simulación
+El archivo [`gro_model.py`](../gro_model.py) muestra cómo calcular curvas de rotación usando esta idea sin recurrir a partículas invisibles.

--- a/gro_model.py
+++ b/gro_model.py
@@ -1,0 +1,59 @@
+"""Gravedad Relativista Oscura (GRO)
+
+This module implements a conceptual model inspired by Einstein's general relativity
+where the effects attributed to dark matter arise from an alternative geometry
+of space-time. The approach modifies the effective gravitational potential with
+an exponential term that mimics the additional attraction usually associated
+with dark matter in galaxies.
+
+The implementation is intentionally simple and should be viewed as a toy example
+for exploring ideas that connect relativistic curvature with observable
+galactic dynamics.
+"""
+
+import math
+
+# Gravitational constant in units of kpc * (km/s)^2 / Msun
+G = 4.302e-6
+
+
+def gro_potential(M: float, r: float, alpha: float = 0.1, r0: float = 5.0) -> float:
+    """Return the modified gravitational potential in the GRO framework.
+
+    Parameters
+    ----------
+    M : float
+        Mass in solar masses.
+    r : float
+        Radius in kiloparsecs.
+    alpha : float, optional
+        Strength of the geometric modification.
+    r0 : float, optional
+        Scale length for the modification.
+    """
+    return -G * M / r * (1 + alpha * math.exp(-r / r0))
+
+
+def gro_rotation_velocity(M: float, r: float, alpha: float = 0.1, r0: float = 5.0) -> float:
+    """Rotation speed predicted by GRO at radius ``r``.
+
+    The expression includes the Newtonian term plus a correction that
+depends on ``alpha`` and ``r0``. Setting ``alpha=0`` recovers the classic
+Keplerian falloff.
+    """
+    term = 1.0 + alpha * (1.0 + r / r0) * math.exp(-r / r0)
+    return math.sqrt(G * M / r * term)
+
+
+def demo() -> None:
+    """Print rotation curves for a simple galaxy using GRO."""
+    radii = [0.5 + 0.2 * i for i in range(100)]
+    M = 1.0e11  # solar masses
+    newtonian = [math.sqrt(G * M / r) for r in radii]
+    gro = [gro_rotation_velocity(M, r) for r in radii]
+    for r, v_n, v_g in zip(radii, newtonian, gro):
+        print(f"{r:5.2f} kpc -> Newtonian: {v_n:7.2f} km/s, GRO: {v_g:7.2f} km/s")
+
+
+if __name__ == "__main__":
+    demo()


### PR DESCRIPTION
## Summary
- create `gro_model.py` with a toy implementation of the "Gravedad Relativista Oscura" potential and a demo
- document the model rationale in `docs/GRO.md`

## Testing
- `python -m py_compile gro_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6841c78fc60c8322a94fe35d8bffa913