### PR TITLE
Add dark matter Riemann analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ apariciones. Para ejecutarlo solo necesitas PyTorch instalado y luego lanzar
 python zero_transformer.py
 ```
 
+### Análisis de materia oscura y ceros de Riemann
+
+El script `dark_matter_riemann_analysis.py` combina datos simulados de materia
+oscura con los primeros ceros de Riemann para buscar correlaciones simples.
+Genera una señal ficticia de conteos de materia oscura y calcula la
+correlación cruzada con las partes imaginarias de los ceros. Puedes ejecutarlo
+con:
+
+```bash
+python dark_matter_riemann_analysis.py -n 20
+```
+
 ## Responsible Use
 
 Llama models are a new technology that carries potential risks with use. Testing conducted to date has not — and could not — cover all scenarios.

--- a/dark_matter_riemann_analysis.py
+++ b/dark_matter_riemann_analysis.py
@@ -1,0 +1,40 @@
+import argparse
+from typing import List
+import mpmath as mp
+import numpy as np
+
+from riemann_zero_explorer import find_zeros
+
+mp.dps = 50  # ensure high precision for Riemann zeros
+
+
+def generate_dark_matter_signal(n: int) -> np.ndarray:
+    """Generate a mock dark matter signal as random counts."""
+    rng = np.random.default_rng()
+    # using Poisson distribution to mimic rare event counts
+    return rng.poisson(lam=5.0, size=n)
+
+
+def correlate_sequences(seq1: np.ndarray, seq2: np.ndarray) -> np.ndarray:
+    """Return the cross-correlation between two sequences."""
+    return np.correlate(seq1 - seq1.mean(), seq2 - seq2.mean(), mode="full")
+
+
+def analyze(n: int):
+    zeros = find_zeros(n)
+    zero_imag = np.array([mp.im(z) for z in zeros], dtype=float)
+    dm_signal = generate_dark_matter_signal(n)
+
+    correlation = correlate_sequences(zero_imag, dm_signal)
+    print("Riemann zeros (imag parts):", zero_imag)
+    print("Dark matter signal:", dm_signal)
+    print("Cross-correlation:", correlation)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Analyze mock dark matter data against Riemann zeros"
+    )
+    parser.add_argument("-n", type=int, default=10, help="Number of points to compute")
+    args = parser.parse_args()
+    analyze(args.n)


### PR DESCRIPTION
## Summary
- add a `dark_matter_riemann_analysis.py` example to look for correlations between simulated dark matter data and Riemann zeros
- document new example in the README

## Testing
- `python -m py_compile dark_matter_riemann_analysis.py`
- `TOKENIZER_PATH=models/llama3_1/tokenizer.model python -m unittest models/llama3_1/api/test_tokenizer.py` *(fails: AssertionError: models/llama3_1/tokenizer.model)*

------
https://chatgpt.com/codex/tasks/task_e_6841cc4aa2708322bee0b71404ff4489