### PR TITLE
Add Moltbook agent scaffold and README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ apariciones. Para ejecutarlo solo necesitas PyTorch instalado y luego lanzar
 python zero_transformer.py
 ```
 
+### Agente Moltbook (experimental)
+
+El archivo `moltbook_agent.py` incluye un agente base en español para organizar
+notas, generar resúmenes y proponer acciones dentro de un cuaderno digital
+llamado Moltbook. Puedes imprimir el prompt generado con:
+
+```bash
+python moltbook_agent.py --demo --nota "Plan de proyecto..." --contexto "Trabajo"
+```
+
 ## Responsible Use
 
 Llama models are a new technology that carries potential risks with use. Testing conducted to date has not — and could not — cover all scenarios.

--- a/moltbook_agent.py
+++ b/moltbook_agent.py
@@ -1,0 +1,170 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# top-level folder for each specific model found within the models/ directory at
+# the top-level of this source tree.
+
+"""Agente base para Moltbook.
+
+Este módulo define un agente configurable que organiza notas, genera resúmenes
+breves y propone acciones para un cuaderno digital llamado Moltbook.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+from jinja2 import Template
+
+DEFAULT_SYSTEM_PROMPT = """
+Eres Moltbook, un asistente de IA para organizar cuadernos digitales.
+Tu misión es ayudar a las personas a capturar, estructurar y recuperar ideas.
+Responde siempre en español claro y directo.
+
+Reglas:
+- Resume con precisión sin inventar datos.
+- Propón etiquetas útiles y accionables.
+- Sugiere próximos pasos concretos.
+- Cuando falte información, formula preguntas breves.
+""".strip()
+
+PROMPT_TEMPLATE = Template(
+    """
+{{ system_prompt }}
+
+Contexto de usuario:
+{{ context or "(sin contexto adicional)" }}
+
+Nota actual:
+{{ note or "(sin nota adjunta)" }}
+
+Solicitud del usuario:
+{{ user_message }}
+
+Responde con:
+1. Resumen (máx. {{ max_summary_tokens }} palabras)
+2. Etiquetas sugeridas ({{ max_tags }} máximo)
+3. Acciones recomendadas ({{ max_action_items }} máximo)
+4. Preguntas de aclaración si son necesarias
+""".strip()
+)
+
+
+@dataclass
+class ToolSpec:
+    name: str
+    description: str
+    arguments: Dict[str, str]
+
+
+@dataclass
+class MoltbookAgentConfig:
+    system_prompt: str = DEFAULT_SYSTEM_PROMPT
+    locale: str = "es-ES"
+    max_summary_tokens: int = 120
+    max_tags: int = 6
+    max_action_items: int = 5
+    tools: List[ToolSpec] = field(
+        default_factory=lambda: [
+            ToolSpec(
+                name="buscar_en_moltbook",
+                description="Busca notas relacionadas por texto o etiqueta.",
+                arguments={"query": "Texto o etiquetas a buscar."},
+            ),
+            ToolSpec(
+                name="crear_recordatorio",
+                description="Crea un recordatorio con fecha y contexto.",
+                arguments={"titulo": "Título breve.", "fecha": "ISO-8601"},
+            ),
+        ]
+    )
+
+
+class MoltbookAgent:
+    def __init__(self, config: Optional[MoltbookAgentConfig] = None) -> None:
+        self.config = config or MoltbookAgentConfig()
+
+    def build_prompt(
+        self,
+        user_message: str,
+        note: Optional[str] = None,
+        context: Optional[str] = None,
+    ) -> str:
+        return PROMPT_TEMPLATE.render(
+            system_prompt=self.config.system_prompt,
+            user_message=user_message,
+            note=note,
+            context=context,
+            max_summary_tokens=self.config.max_summary_tokens,
+            max_tags=self.config.max_tags,
+            max_action_items=self.config.max_action_items,
+        )
+
+    def generate_response(
+        self,
+        llm: Callable[[str], str],
+        user_message: str,
+        note: Optional[str] = None,
+        context: Optional[str] = None,
+    ) -> str:
+        prompt = self.build_prompt(user_message, note=note, context=context)
+        return llm(prompt)
+
+    def analyze_note(
+        self,
+        llm: Callable[[str], str],
+        note: str,
+        context: Optional[str] = None,
+    ) -> str:
+        user_message = (
+            "Analiza la nota para crear un resumen, etiquetas y acciones."
+        )
+        return self.generate_response(llm, user_message, note=note, context=context)
+
+
+def demo_llm(prompt: str) -> str:
+    return f"--- PROMPT GENERADO ---\n{prompt}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Agente base para Moltbook.")
+    parser.add_argument(
+        "--nota",
+        dest="note",
+        help="Contenido de la nota a analizar.",
+    )
+    parser.add_argument(
+        "--contexto",
+        dest="context",
+        help="Contexto adicional del usuario.",
+    )
+    parser.add_argument(
+        "--mensaje",
+        dest="message",
+        default="Ayúdame a organizar esta nota.",
+        help="Solicitud del usuario.",
+    )
+    parser.add_argument(
+        "--demo",
+        action="store_true",
+        help="Imprime el prompt generado en lugar de llamar a un modelo.",
+    )
+    args = parser.parse_args()
+
+    agent = MoltbookAgent()
+    if args.demo:
+        response = agent.generate_response(
+            demo_llm, args.message, note=args.note, context=args.context
+        )
+    else:
+        response = agent.generate_response(
+            demo_llm, args.message, note=args.note, context=args.context
+        )
+    print(response)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a simple, local scaffold for an AI assistant (Moltbook) that helps organize notes, generate concise summaries and suggest actions in Spanish.
- Offer a reusable prompt template and configuration so integrations can call an LLM or run a CLI demo without reimplementing prompt construction.

### Description
- Add `moltbook_agent.py`, a self-contained agent scaffold that defines `MoltbookAgent`, `MoltbookAgentConfig`, `ToolSpec`, a Jinja2-based prompt template, and a `demo_llm` for local prompt inspection.
- Implement a small CLI in `moltbook_agent.py` with arguments `--nota`, `--contexto`, `--mensaje`, and `--demo` so the generated prompt can be printed for testing; run the demo with `python moltbook_agent.py --demo --nota "Plan de proyecto..." --contexto "Trabajo"`.
- Document the new agent and example usage in `README.md` under a new "Agente Moltbook (experimental)" section.
- Keep the scaffold implementation LLM-agnostic by accepting a callable `llm: Callable[[str], str]` to produce responses.

### Testing
- No automated tests were run for this change (no test suite execution was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a51f2500832faead2897e867dd89)